### PR TITLE
Sponsor card link

### DIFF
--- a/event/app/admin/(manage-event)/[id]/sponsors/page.jsx
+++ b/event/app/admin/(manage-event)/[id]/sponsors/page.jsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import { useState } from "react";
 import Link from "next/link";
@@ -8,21 +8,21 @@ import { Modal } from "@/app/components/Modal";
 import "./page.css";
 
 export default function ManageSponsorsPage({ params }) {
-    const [ showModal, setShowModal ] = useState(false);
-    const [ sponsor, setSponsor ] = useState();
+    const [showModal, setShowModal] = useState(false);
+    const [sponsor, setSponsor] = useState();
 
     const handleDeleteClick = (sponsor) => {
         setSponsor(sponsor);
         setShowModal(!showModal);
-    }
+    };
 
     const handleDeleteSponsor = () => {
         console.log(`delete ${sponsor.name}`);
-    }
+    };
 
     const handleToggleModal = () => {
         setShowModal(!showModal);
-    }
+    };
 
     return (
         <main id="manage-sponsors-page" className="gap">
@@ -31,24 +31,23 @@ export default function ManageSponsorsPage({ params }) {
             <section className="sponsors max-width">
                 {SPONSORS.map((sponsor, index) => (
                     <div className="sponsor-wrapper" key={index}>
-                        <Link href="sponsors/edit">
-                            <SponsorCard
-                                image={sponsor.image}
-                                title={sponsor.name}
-                                description={sponsor.description}
-                            />
-                        </Link>
-                        <button className="delete-btn" onClick={() => handleDeleteClick(sponsor)}> Radera </button>
+                        <SponsorCard sponsor={sponsor} external={false} />
+                        <button className="delete-btn" onClick={() => handleDeleteClick(sponsor)}>
+                            Radera
+                        </button>
                     </div>
                 ))}
             </section>
 
-            {showModal ? <Modal 
-                            title={sponsor.name}
-                            closeModal={handleToggleModal} 
-                            confirm={handleDeleteSponsor} 
-                        /> : <></> 
-            }
+            {showModal ? (
+                <Modal
+                    title={sponsor.name}
+                    closeModal={handleToggleModal}
+                    confirm={handleDeleteSponsor}
+                />
+            ) : (
+                <></>
+            )}
 
             <Link href="/admin/1/sponsors/add" className="manage-sponsors__add-link">
                 <button className="add-btn"></button>
@@ -59,24 +58,28 @@ export default function ManageSponsorsPage({ params }) {
 
 const SPONSORS = [
     {
+        url: "sponsors/edit",
         name: "McDonald's",
         description:
             "Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus doloribus ex, omnis nulla similique itaque reprehenderit, ut nemo hic cupiditate molestias voluptatem necessitatibus quibusdam ea incidunt ipsum eveniet maiores adipisci assumenda numquam! Dolore quasi exercitationem saepe aperiam, id ut. Ullam alias obcaecati eum error dignissimos commodi excepturi qui nam cumque?",
         image: "https://picsum.photos/200",
     },
     {
+        url: "sponsors/edit",
         name: "Lamborghini",
         description:
             "Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus doloribus ex, omnis nulla similique itaque reprehenderit, ut nemo hic cupiditate molestias voluptatem necessitatibus quibusdam ea incidunt ipsum eveniet maiores adipisci assumenda numquam! Dolore quasi exercitationem saepe aperiam, id ut. Ullam alias obcaecati eum error dignissimos commodi excepturi qui nam cumque?",
         image: "https://picsum.photos/200",
     },
     {
+        url: "sponsors/edit",
         name: "Pizza Hut",
         description:
             "Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus doloribus ex, omnis nulla similique itaque reprehenderit, ut nemo hic cupiditate molestias voluptatem necessitatibus quibusdam ea incidunt ipsum eveniet maiores adipisci assumenda numquam! Dolore quasi exercitationem saepe aperiam, id ut. Ullam alias obcaecati eum error dignissimos commodi excepturi qui nam cumque?",
         image: "https://picsum.photos/200",
     },
     {
+        url: "sponsors/edit",
         name: "Tesla",
         description:
             "Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus doloribus ex, omnis nulla similique itaque reprehenderit, ut nemo hic cupiditate molestias voluptatem necessitatibus quibusdam ea incidunt ipsum eveniet maiores adipisci assumenda numquam! Dolore quasi exercitationem saepe aperiam, id ut. Ullam alias obcaecati eum error dignissimos commodi excepturi qui nam cumque?",

--- a/event/app/admin/(manage-event)/[id]/sponsors/page.jsx
+++ b/event/app/admin/(manage-event)/[id]/sponsors/page.jsx
@@ -31,7 +31,7 @@ export default function ManageSponsorsPage({ params }) {
             <section className="sponsors max-width">
                 {SPONSORS.map((sponsor, index) => (
                     <div className="sponsor-wrapper" key={index}>
-                        <SponsorCard sponsor={sponsor} external={false} />
+                        <SponsorCard sponsor={sponsor} />
                         <button className="delete-btn" onClick={() => handleDeleteClick(sponsor)}>
                             Radera
                         </button>

--- a/event/app/components/SponsorCard.css
+++ b/event/app/components/SponsorCard.css
@@ -1,33 +1,44 @@
-.sponsor-card {
-    display: flex;
-
-    & .sponsor-card__figure {
-        width: 100%;
-        display: flex;
-
-        & img {
-            border-radius: var(--radius) 0 0 var(--radius);
-            object-fit: cover;
-            object-position: center;
-        }
+.sponsor-card-link {
+    &:hover {
+        color: inherit;
+        scale: 1.01;
+        filter: brightness(0.9);
     }
 
-    & .sponsor-card-wrapper {
+    & .sponsor-card {
         display: flex;
-        flex-direction: column;
-        gap: 1rem;
-        padding: 1rem;
+        background-color: var(--white);
+
+        & .sponsor-card__figure {
+            width: 100%;
+            display: flex;
+
+            & img {
+                border-radius: var(--radius) 0 0 var(--radius);
+                object-fit: cover;
+                object-position: center;
+            }
+        }
+
+        & .sponsor-card-wrapper {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            padding: 1rem;
+        }
     }
 }
 
 @media (max-width: 800px) {
-    .sponsor-card {
-        flex-direction: column;
+    .sponsor-card-link {
+        .sponsor-card {
+            flex-direction: column;
 
-        & .sponsor-card__figure {
-            & img {
-                border-radius: var(--radius) var(--radius) 0 0;
-                height: 16rem;
+            & .sponsor-card__figure {
+                & img {
+                    border-radius: var(--radius) var(--radius) 0 0;
+                    height: 16rem;
+                }
             }
         }
     }

--- a/event/app/components/SponsorCard.jsx
+++ b/event/app/components/SponsorCard.jsx
@@ -3,9 +3,9 @@ import Link from "next/link";
 
 import "./SponsorCard.css";
 
-export default function SponsorCard({ sponsor, external }) {
+export default function SponsorCard({ sponsor, target="_self" }) {
     return (
-        <Link className="sponsor-card-link" href={sponsor.url} target={external ? "_blank" : ""}>
+        <Link className="sponsor-card-link" href={sponsor.url} target={target}>
             <article className="sponsor-card box-shadow b-radius">
                 <figure className="sponsor-card__figure">
                     <Image

--- a/event/app/components/SponsorCard.jsx
+++ b/event/app/components/SponsorCard.jsx
@@ -1,17 +1,25 @@
 import Image from "next/image";
+import Link from "next/link";
 
 import "./SponsorCard.css";
 
-export default function SponsorCard({ image, title, description }) {
+export default function SponsorCard({ sponsor, external }) {
     return (
-        <article className="sponsor-card box-shadow b-radius">
-            <figure className="sponsor-card__figure">
-                <Image src={image} width={200} height={200} alt={`${title} sponsor image`} />
-            </figure>
-            <div className="sponsor-card-wrapper">
-                <h3 className="sponsor-card__title">{title}</h3>
-                <p className="sponsor-card__description">{description}</p>
-            </div>
-        </article>
+        <Link className="sponsor-card-link" href={sponsor.url} target={external ? "_blank" : ""}>
+            <article className="sponsor-card box-shadow b-radius">
+                <figure className="sponsor-card__figure">
+                    <Image
+                        src={sponsor.image}
+                        width={200}
+                        height={200}
+                        alt={`${sponsor.name} sponsor image`}
+                    />
+                </figure>
+                <div className="sponsor-card-wrapper">
+                    <h3 className="sponsor-card__title">{sponsor.name}</h3>
+                    <p className="sponsor-card__description">{sponsor.description}</p>
+                </div>
+            </article>
+        </Link>
     );
 }

--- a/event/app/triathlon/sponsors/page.jsx
+++ b/event/app/triathlon/sponsors/page.jsx
@@ -4,12 +4,14 @@ import "./page.css";
 
 const SPONSORS = [
     {
+        url: "https://nextjs.org/",
         name: "McDonald's",
         description:
             "Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus doloribus ex, omnis nulla similique itaque reprehenderit, ut nemo hic cupiditate molestias voluptatem necessitatibus quibusdam ea incidunt ipsum eveniet maiores adipisci assumenda numquam! Dolore quasi exercitationem saepe aperiam, id ut. Ullam alias obcaecati eum error dignissimos commodi excepturi qui nam cumque?",
         image: "https://picsum.photos/200",
     },
     {
+        url: "https://www.google.com/",
         name: "Lamborghini",
         description:
             "Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus doloribus ex, omnis nulla similique itaque reprehenderit, ut nemo hic cupiditate molestias voluptatem necessitatibus quibusdam ea incidunt ipsum eveniet maiores adipisci assumenda numquam! Dolore quasi exercitationem saepe aperiam, id ut. Ullam alias obcaecati eum error dignissimos commodi excepturi qui nam cumque?",
@@ -22,13 +24,8 @@ export default function SponsorsPage() {
         <main id="sponsorspage" className="max-width gap">
             <section className="sponsors">
                 <h1 className="sponsors__title">Sponsorer</h1>
-                {SPONSORS.map((sponsor) => (
-                    <SponsorCard
-                        image={sponsor.image}
-                        title={sponsor.name}
-                        description={sponsor.description}
-                        key={sponsor.name}
-                    />
+                {SPONSORS.map((sponsor, index) => (
+                    <SponsorCard sponsor={sponsor} external={true} key={index} />
                 ))}
             </section>
             <section className="sponsor-event">
@@ -45,7 +42,9 @@ export default function SponsorsPage() {
                         <label htmlFor="phonenumber">Telefonnummer</label>
                         <input id="phonenumber" name="phonenumber" type="tel" />
                     </div>
-                    <button className="sponsor-event__submit" type="submit">Skicka</button>
+                    <button className="sponsor-event__submit" type="submit">
+                        Skicka
+                    </button>
                 </form>
             </section>
         </main>

--- a/event/app/triathlon/sponsors/page.jsx
+++ b/event/app/triathlon/sponsors/page.jsx
@@ -25,7 +25,7 @@ export default function SponsorsPage() {
             <section className="sponsors">
                 <h1 className="sponsors__title">Sponsorer</h1>
                 {SPONSORS.map((sponsor, index) => (
-                    <SponsorCard sponsor={sponsor} external={true} key={index} />
+                    <SponsorCard sponsor={sponsor} target="_blank" key={index} />
                 ))}
             </section>
             <section className="sponsor-event">


### PR DESCRIPTION
Wrap SponsorCard in a Link. Add a hover effect. SponsorCard now takes a sponsor object and target. The target prop is default to "_self" which is default behavior, and "_blank" can be provided when using external links to open a new tab.